### PR TITLE
Add VS2019 support

### DIFF
--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -10,16 +10,16 @@
 		<Tags>Zoom, AutoZoom</Tags>
 	</Metadata>
 	<Installation>
-		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[12.0,16.0)" />
-		<InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-		<InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[12.0,17.0)" />
+		<InstallationTarget Version="[12.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+		<InstallationTarget Version="[12.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
 	</Installation>
 	<Dependencies>
 		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
 		<Dependency Id="Microsoft.VisualStudio.MPF.12.0" DisplayName="Visual Studio MPF 12.0" d:Source="Installed" Version="[12.0,16.0)" />
 	</Dependencies>
 	<Prerequisites>
-		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[12.0,16.0)" DisplayName="Visual Studio core editor" />
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[12.0,)" DisplayName="Visual Studio core editor" />
 	</Prerequisites>
 	<Assets>
 		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
It looks like the `Resources\AutoZoomPackage.ico` file is missing, but I was able to recreate it from the png to test this.  Afaict, with these changes it is installing and working fine in VS2019 preview 3.

Thanks for making this!